### PR TITLE
Add options to selected included/excluded svg paths

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,4 +4,3 @@ indent_style = space
 indent_size = 2
 end_of_line = lf
 insert_final_newline = true
-trim_trailing_whitespace = true

--- a/.eslintrc
+++ b/.eslintrc
@@ -3,6 +3,9 @@
   "rules": {
     "space-before-function-paren": "off",
     "func-names": "off",
-    "arrow-parens": ["error", "as-needed"]
+    "arrow-parens": ["error", "as-needed"],
+    "no-use-before-define": "off",
+    "semi": "off",
+    "max-len": "off"
   }
 }

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A parcel plugin which create a svg sprite of imported svg and inject it in html 
 
 > warning : this plugin overwrite HTMLPackager, it can be in conflit with other plugin which also overwrite HTMLPackager.
 
-> Until version `1.1.2` files in an `assets` folder or subfolder wasn't injected in sprite to have the possibility to use svg files in css (css can't reference a svg symbol)
+> Until version `1.1.2` files in an `assets` folder or subfolder wasn't injected in sprite to have the possibility to use svg files in css (css can't reference a svg symbol).  
 > Since version `1.2.0` you can use options `include` and `exclude` to define path patterns you don't want to inject in sprite and import them as file url.
 > This can be usefull to import svg font in css or to use svg file in css background-image.
 
@@ -24,7 +24,7 @@ In html file :
 ...
 <body>
   ...
-  <!-- relative path to the html file -->
+  <!-- relative path from the html file -->
   <svg>
     <use href="icons/checkmark.svg">
   </svg>
@@ -57,13 +57,58 @@ const icon = (
 
 When you import a svg, you get the id of the symbol generated in built sprite. This is why you can use it as `xlink:href` attribute.
 
+#### HTML input example:
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>Document</title>
+</head>
+<body>
+  <div id="app"></div>
+  <script src="app.tsx"></script>
+</body>
+</html>
+```
+
+#### Generated HTML expected
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>Document</title>
+</head>
+<body>
+  <!-- Begin of svg sprite wrapper -->
+  <svg width="0" height="0" style="position:absolute">
+    <symbol id="generated_symbol_id_1" xmlns="http://www.w3.org/2000/svg">
+      <!-- first imported svg file content -->
+    </symbol>
+    <symbol id="generated_symbol_id_2" xmlns="http://www.w3.org/2000/svg">
+      <!-- second imported svg file content -->
+    </symbol>
+    ...
+  </svg>
+  <!-- End of svg sprite wrapper -->
+  <div id="app"></div>
+  <script src="app.tsx"></script>
+</body>
+</html>
+```
+
 ### Options :
 
-This plugin has a 2 options to give the possibility to handle specific cases.  
+This plugin has 2 options to give the possibility to handle specific cases.  
 Those options can be set only in `package.json` in the field `svgSpriteOptions`.
 
 **exclude** `string[]`  
-List of glob patterns which should not be included in svg sprite and imported as file url which Parcel default behavior.  
+List of glob patterns which should not be included in svg sprite and should be imported as file url (like Parcel's default behavior).  
 This can be usefull if you need to import file in css (for font or background-image).  
 example (to avoid inject files from assets folder in svg sprite):
 ```json

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@ A parcel plugin which create a svg sprite of imported svg and inject it in html 
 
 > warning : this plugin overwrite HTMLPackager, it can be in conflit with other plugin which also overwrite HTMLPackager.
 
+> Until version `1.1.2` files in an `assets` folder or subfolder wasn't injected in sprite to have the possibility to use svg files in css (css can't reference a svg symbol)
+> Since version `1.2.0` you can use options `include` and `exclude` to define path patterns you don't want to inject in sprite and import them as file url.
+> This can be usefull to import svg font in css or to use svg file in css background-image.
+
 ### Installation
 ```bash
 yarn add -D parcel-plugin-svg-sprite
@@ -53,8 +57,37 @@ const icon = (
 
 When you import a svg, you get the id of the symbol generated in built sprite. This is why you can use it as `xlink:href` attribute.
 
-But if the svg file is in an `assets` folder, the plugin will ignore the file and the import will return the url of the file.
-> This behavior was added to avoid impacts on svg font loaded by css. For the moment, I didn't find a better way to handle this case.
+### Options :
+
+This plugin has a 2 options to give the possibility to handle specific cases.  
+Those options can be set only in `package.json` in the field `svgSpriteOptions`.
+
+**exclude** `string[]`  
+List of glob patterns which should not be included in svg sprite and imported as file url which Parcel default behavior.  
+This can be usefull if you need to import file in css (for font or background-image).  
+example (to avoid inject files from assets folder in svg sprite):
+```json
+// package.json
+"name": "my-package-name",
+...
+"svgSpriteOptions": {
+  "exclude": ["**/assets/**/*"]
+}
+```
+
+**include** `string[]`  
+List of glob patterns which can be injected in svg sprite.  
+If the option isn't set all svg file which aren't exluded will be injected in svg sprite.  
+If a file path matches with both include and exclude options, the path will be excluded.  
+example:
+```json
+// package.json
+"name": "my-package-name",
+...
+"svgSpriteOptions": {
+  "include": ["src/**/*"]
+}
+```
 
 ### Advantages :
 - Unlike initial parcel behaviour which return an url, here you can apply css to customise the imported svg (for example the color, the stroke, ...)
@@ -71,7 +104,7 @@ This plugin was developped to create icon system based on svg.
 As long as you import little svg and the size of the sprite isn't too heavy, I think there isn't any problem (it depends on your case but in my opinion the sprite should not exceed 100kb).
 If you have to much icons, there is a risk to have a significantly bad impact on the delay of first render of your web app.
 
-### In which case I didn't recommend this plugin
+### In which case I don't recommend this plugin
 Like I said above, if you want to import a lot of svg files, or big illustrations, this plugin is not good for your case.
 You first render time can be too much delayed.
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "fs-extra": "^7.0.1",
+    "glob": "^7.1.4",
     "lodash": "^4.17.11",
     "posthtml": "^0.11.4",
     "svg-sprite": "^1.5.0",

--- a/src/asset.js
+++ b/src/asset.js
@@ -1,7 +1,28 @@
 const { Asset } = require('parcel-bundler');
+const urlJoin = require('parcel-bundler/lib/utils/urlJoin');
+const md5 = require('parcel-bundler/lib/utils/md5');
 const { isPathIncluded, createHash } = require('./utils');
 
 class SvgAsset extends Asset {
+  /**
+   * @desc check if we use raw asset behavior or svg sprite behavior
+   */
+  useRawAssetsBehavior() {
+    return !isPathIncluded(this.name);
+  }
+
+  /**
+   * @desc load asset contents
+   */
+  // eslint-disable-next-line consistent-return
+  load() {
+    if (this.useRawAssetsBehavior()) {
+      // we do nothing because it will be copied by the RawPackager directly.
+    } else {
+      return super.load();
+    }
+  }
+
   /**
    * @desc Generate asset of an svg file imported by js bundle
    *
@@ -11,9 +32,17 @@ class SvgAsset extends Asset {
   async generate() {
     const hash = await this.generateHash();
 
-    // if path isn't include, we keep original behavior with RawAssets
-    if (!isPathIncluded(this.name)) {
-      return {};
+    // if path isn't include, we keep original RawAsset behavior
+    if (this.useRawAssetsBehavior()) {
+      // code copied from RawAsset to copy RawAsset behavior
+      // https://github.com/parcel-bundler/parcel/blob/master/packages/core/parcel-bundler/src/assets/RawAsset.js
+      const pathToAsset = urlJoin(this.options.publicURL, this.generateBundleName());
+      return [
+        {
+          type: 'js',
+          value: `module.exports=${JSON.stringify(pathToAsset)};`,
+        },
+      ];
     }
 
     return [
@@ -27,7 +56,7 @@ class SvgAsset extends Asset {
       },
       {
         type: 'js',
-        value: `module.exports = '#${hash}'`,
+        value: `module.exports='#${hash}'`,
       },
     ];
   }
@@ -37,7 +66,11 @@ class SvgAsset extends Asset {
    * @return {string}
    */
   async generateHash() {
-    return createHash(this.contents).toString();
+    if (this.content) {
+      return createHash(this.contents).toString();
+    }
+
+    return md5.file(this.name);
   }
 }
 

--- a/src/asset.js
+++ b/src/asset.js
@@ -26,12 +26,9 @@ class SvgAsset extends Asset {
   /**
    * @desc Generate asset of an svg file imported by js bundle
    *
-   * @return empty object if file path is not include or exluded
-   *         or the svg assets for SvgPackager wth a js asset which contain svg symbol id
+   * @return generated assets for packagers
    */
   async generate() {
-    const hash = await this.generateHash();
-
     // if path isn't include, we keep original RawAsset behavior
     if (this.useRawAssetsBehavior()) {
       // code copied from RawAsset to copy RawAsset behavior
@@ -44,6 +41,8 @@ class SvgAsset extends Asset {
         },
       ];
     }
+
+    const hash = await this.generateHash();
 
     return [
       {

--- a/src/asset.js
+++ b/src/asset.js
@@ -1,21 +1,18 @@
 const { Asset } = require('parcel-bundler');
-const { createHash } = require('./utils');
+const { isPathIncluded, createHash } = require('./utils');
 
 class SvgAsset extends Asset {
   /**
    * @desc Generate asset of an svg file imported by js bundle
-   * We consider that files from an `assets` folder has to be imported has RawAssets
    *
-   * @return empty object if file is in an `assets` folder
+   * @return empty object if file path is not include or exluded
    *         or the svg assets for SvgPackager wth a js asset which contain svg symbol id
    */
   async generate() {
-    // this is used to keep original behavior with files imported by css for font
-    // here `parentBundle` is null so we can't know if svg is imported by a css file
-    const isFromAssets = this.name.includes('/assets/');
     const hash = await this.generateHash();
 
-    if (isFromAssets) {
+    // if path isn't include, we keep original behavior with RawAssets
+    if (!isPathIncluded(this.name)) {
       return {};
     }
 

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -1,0 +1,126 @@
+const path = require('path');
+const fse = require('fs-extra');
+const glob = require('glob');
+
+/**
+ * @desc Create a svg sprite with <symbol> elements
+ * @param {object[]} svgList - list of svg info for sprite creation
+ * @param {string} svgList[].path
+ * @param {string} svgList[].hash
+ * @param {string} svgList[].content
+ * @return {Promise} promise with svg sprite string
+ */
+function getConfig() {
+  const packagePath = path.resolve('package.json');
+  const packageContent = fse.readJsonSync(packagePath);
+  if (packageContent && packageContent.svgSpriteOptions) {
+    const { include, exclude } = packageContent.svgSpriteOptions;
+
+    // check options
+    if (include && !isStringArray(include)) {
+      throw new Error('include option must be an array of string');
+    }
+    if (exclude && !isStringArray(exclude)) {
+      throw new Error('include option must be an array of string');
+    }
+
+    return {
+      include: include || null,
+      exclude: exclude || null,
+    };
+  }
+
+  // if option doesn't exist, we set default options
+  return {
+    include: null,
+    exclude: null,
+  };
+}
+
+/**
+ * @desc Get list of files which can be include
+ *       files will be include in sprite only if file is imported
+ * @param {object} config - plugin config
+ * @param {string[] | null} config.include - glob pattern to include
+ * @param {string[] | null} config.exclude - glob pattern to exclude
+ * @param {string[] | null} excludePaths - path to exclude
+ * @return {string[] | null}
+ */
+function getIncludePaths(config, excludePaths) {
+  if (config.include) {
+    // second params will avoid to have path which are in excludePaths
+    // in case there are intersection between `include` and `exclude` patterns
+    return getPaths(config.include, excludePaths || []);
+  }
+  return null;
+}
+
+/**
+ * @desc Get list of files which will not be include
+ *       instead those file will be imported with original behavior
+ *       (copy the file in dist folder)
+ * @param {object} config - plugin config
+ * @param {string[] | null} config.include - glob pattern to include
+ * @param {string[] | null} config.exclude - glob pattern to exclude
+ * @return {string[] | null}
+ */
+function getExcludePaths(config) {
+  if (config.exclude) {
+    return getPaths(config.exclude);
+  }
+  return null;
+}
+
+/**
+ * @desc Get list of path of svg files which match with a glob pattern
+ * @param {string[]} patterns
+ * @param {string[]} exclude - path to exclude
+ * @return {string[]}
+ */
+function getPaths(patterns, exclude = []) {
+  const svgPaths = [];
+
+  patterns.forEach(pattern => {
+    const matches = glob.sync(pattern);
+    matches.forEach(match => {
+      const extension = path.extname(match);
+
+      // we push only svg file because this plugin works only svg files
+      if (extension === '.svg') {
+        const absolutePath = path.resolve(match);
+
+        const alreadyInclude = svgPaths.some(svgPath => absolutePath === svgPath);
+        const excluded = exclude.some(excludePath => absolutePath === excludePath);
+
+        // avoid doublons and paths which are exluded
+        if (!alreadyInclude && !excluded) {
+          svgPaths.push(absolutePath);
+        }
+      }
+    });
+  });
+
+  return svgPaths;
+}
+
+/**
+ * @desc Check if a value is an array of string
+ * @param {any} value
+ * @return {boolean}
+ */
+function isStringArray(value) {
+  if (Array.isArray(value)) {
+    return value.every(v => typeof v === 'string');
+  }
+  return false;
+}
+
+const config = getConfig();
+const excludePaths = getExcludePaths(config);
+const includePaths = getIncludePaths(config, excludePaths);
+
+module.exports = {
+  config,
+  includePaths,
+  excludePaths,
+};

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const XXHash = require('xxhashjs');
+const { includePaths, excludePaths } = require('./config');
 const { createSprite } = require('./sprite');
 
 const STYLE_EXTENSIONS = ['.css', '.scss', '.sass', '.less', '.styl'];
@@ -30,7 +31,17 @@ function importedByStyle(asset) {
   return false;
 }
 
+function isPathIncluded(filePath) {
+  // if includePaths is null, it means the option doesn't exist so by default we include all svg
+  const isIncluded = includePaths !== null ? includePaths.some(p => p === filePath) : true;
+  // if excludePaths is null, it means the option doesn't exist so by default we don't exclude any svg
+  const isExluded = excludePaths !== null ? excludePaths.some(p => p === filePath) : false;
+
+  return isIncluded && !isExluded;
+}
+
 module.exports = {
+  isPathIncluded,
   createHash,
   importedByStyle,
   createSprite,

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -32,9 +32,9 @@ function importedByStyle(asset) {
 }
 
 function isPathIncluded(filePath) {
-  // if includePaths is null, it means the option doesn't exist so by default we include all svg
+  // if includePaths is null, it means the option isn't set. By default we include all svg
   const isIncluded = includePaths !== null ? includePaths.some(p => p === filePath) : true;
-  // if excludePaths is null, it means the option doesn't exist so by default we don't exclude any svg
+  // if excludePaths is null, it means the option isn't set. By default we don't exclude any svg
   const isExluded = excludePaths !== null ? excludePaths.some(p => p === filePath) : false;
 
   return isIncluded && !isExluded;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2772,7 +2772,7 @@ glob@7.1.2:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.3, glob@^7.1.2, glob@^7.1.3:
+glob@^7.0.3, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
   integrity sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==


### PR DESCRIPTION
The goal of this PR is to give the possibility to chose svg paths to import in sprite and path which shouldn't be imported in the sprite for CSS font or CSS background-image.

For the moment we can avoid importing some svg in sprite by moving those files in an `assets` folder.
The problem with this solution is it can lead to unexpected behavior or force developers to change folder names in their project.

To have a more explicit behavior and let developers chose folder names as they want, I add 2 options which can be set in `package.json`:
- the first option is `exclude`, it takes as argument a list of glob patterns.
each file that matches with one of the patterns will be imported as file url like Parcel's default behavior.
example:
```json
// package.json
"name": "my-package-name",
...
"svgSpriteOptions": {
  "exclude": ["**/assets/**/*"]
}
```

- the second option is `include`, it also takes as argument a list of glob patterns.
when it's set, only svg files which match one of the patterns will be included in the svg sprite.
example:
```json
// package.json
"name": "my-package-name",
...
"svgSpriteOptions": {
  "include": ["src/**/*"]
}
```