### PR TITLE
add aria-hidden attribute for screen readers

### DIFF
--- a/src/utils/sprite.js
+++ b/src/utils/sprite.js
@@ -46,6 +46,11 @@ function createConfig(svgList) {
         inline: true,
       },
     },
+    svg: {
+      rootAttributes: {
+        'aria-hidden': 'true',
+      },
+    },
   };
 }
 


### PR DESCRIPTION
Add aria-hidden attributes for screen readers.

Idea comes from @ryuran issue in `svg-sprite-html-webpack` repo : https://github.com/Epimodev/svg-sprite-html-webpack/issues/10